### PR TITLE
v1.3.7

### DIFF
--- a/assets/css/flat-blocks.css
+++ b/assets/css/flat-blocks.css
@@ -638,6 +638,14 @@ header > .wp-block-cover {
 .wp-block-details > summary:active {
 	color: var(--wp--preset--color--foreground);
 }
+
+/*--------------------------------------------------------------
+# Category or Tag Cloud
+--------------------------------------------------------------*/
+.wp-block-tag-cloud.is-style-outline .tag-cloud-link {
+	border-radius: var(--wp--custom--border--radius);
+	padding: var(--wp--preset--spacing--20) var(--wp--preset--spacing--30);
+}
 	
 /*--------------------------------------------------------------
 # Table Block

--- a/inc/block-styles.php
+++ b/inc/block-styles.php
@@ -163,8 +163,8 @@ if ( ! function_exists( 'flatblocks_register_block_styles' ) ) :
 					array(
 						'name'  => $custom_style,
 						'label' => $label,
-						$inline_style => $properties['inline_style'] ?? '',
-						$style_handle => $properties['style_handle'] ?? 'flatblocks-custom-styles'
+						'inline_style' => $properties['inline_style'] ?? '',
+						'style_handle' => $properties['style_handle'] ?? 'flatblocks-custom-styles'
 					)
 				);
 			} //end foreach $custom_styles

--- a/readme.txt
+++ b/readme.txt
@@ -153,10 +153,16 @@ You can check out our other themes here: https://xtremelysocial.com/wordpress/
 
 == Changelog ==
 
+= 1.3.7 =
+September 7, 2023
+
+* Style the Tag and Category Cloud alternate Outline style to use the theme's border radius (5px by default) and padding. 
+* Enhancement to Block Styles logic to allow inlining styles or referencing a registered style handle. This is mainly for child themes or possible future performance enhancements as WordPress v6 evolves.
+
 = 1.3.6 =
 September 6, 2023
 
-* Quick fix for Block Patterns not loading (block-styles.php).
+* Quick fix for Custom Block Styles not loading (block-styles.php).
 
 = 1.3.5 =
 September 6, 2023

--- a/style.css
+++ b/style.css
@@ -7,7 +7,7 @@ Description: Flat Blocks is a modern “flat” style theme with a nice color pa
 Requires at least: 6.2
 Tested up to: 6.3
 Requires PHP: 7.4
-Version: 1.3.6
+Version: 1.3.7
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: flat-blocks

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/theme.json",
 	"version": 2,
+	"title": "Flat Blocks",
 	"settings": {
 		"custom": {
 			"typography": {


### PR DESCRIPTION
* Style the Tag and Category Cloud alternate Outline style to use the theme's border radius (5px by default) and padding.
* Enhancement to Block Styles logic to allow inlining styles or referencing a registered style handle. This is mainly for child themes or possible future performance enhancements as WordPress v6 evolves.